### PR TITLE
Subnet support for multiple stemcell lines

### DIFF
--- a/pipelines/ubuntu-bionic/credhub-subnet-config.yml
+++ b/pipelines/ubuntu-bionic/credhub-subnet-config.yml
@@ -1,0 +1,54 @@
+credentials:
+- name: /concourse/main/gcp_subnet_master_deploy_director_ipv4
+  type: json
+  value:
+    name: bosh-integration0
+    ip: 10.100.0.10
+    cidr: 10.100.0.0/24
+    gw: 10.100.0.1
+    reserved_range: '10.100.0.2 - 10.100.0.9'
+- name: /concourse/main/gcp_subnet_master_deploy_director
+  type: json
+  value:
+    name: bosh-integration1
+    ip: 10.100.1.10
+    cidr: 10.100.1.0/24
+    gw: 10.100.1.1
+    reserved_range: '10.100.1.2 - 10.100.1.9'
+- name: /concourse/main/gcp_subnet_master_deploy_director
+  type: json
+  value:
+    name: bosh-integration2
+    ip: 10.100.2.30
+    ip2: 10.100.2.15
+    cidr: 10.100.2.0/24
+    gw: 10.100.2.1
+    reserved_range: '10.100.2.2 - 10.100.2.9'
+    static_range: '10.100.2.10 - 10.100.2.30'
+
+- name: /concourse/main/gcp_subnet_1.x_deploy_director
+  type: json
+  value:
+    name: bosh-integration3
+    ip: 10.100.3.10
+    cidr: 10.100.3.0/24
+    gw: 10.100.3.1
+    reserved_range: '10.100.3.2 - 10.100.3.9'
+- name: /concourse/main/gcp_subnet_1.x_deploy_director_ipv4
+  type: json
+  value:
+    name: bosh-integration4
+    ip: 10.100.4.10
+    cidr: 10.100.4.0/24
+    gw: 10.100.4.1
+    reserved_range: '10.100.4.2 - 10.100.4.9'
+- name: /concourse/main/gcp_subnet_1.x_deploy_director
+  type: json
+  value:
+    name: bosh-integration5
+    ip: 10.100.5.30
+    ip2: 10.100.5.15
+    cidr: 10.100.5.0/24
+    gw: 10.100.5.1
+    reserved_range: '10.100.5.2 - 10.100.5.9'
+    static_range: '10.100.5.10 - 10.100.5.30'

--- a/pipelines/ubuntu-bionic/pipeline.yml
+++ b/pipelines/ubuntu-bionic/pipeline.yml
@@ -252,12 +252,12 @@ jobs:
           GCP_PROJECT_ID: ((gcp_project_id))
           GCP_ZONE: europe-west4-a
           GCP_NETWORK_NAME: default
-          GCP_SUBNET_NAME: bosh-integration1
           GCP_JSON_KEY: ((gcp_json_key))
-          INTERNAL_IP: 10.100.0.10
-          INTERNAL_CIDR: 10.100.0.0/24
-          INTERNAL_GW: 10.100.0.1
-          RESERVED_RANGE: '10.100.0.2 - 10.100.0.9'
+          GCP_SUBNET_NAME: ((gcp_subnet(@= stemcell.version @)_deploy_director_ipv4.name))
+          INTERNAL_IP: ((gcp_subnet(@= stemcell.version @)_deploy_director_ipv4.ip))
+          INTERNAL_CIDR: ((gcp_subnet(@= stemcell.version @)_deploy_director_ipv4.cidr))
+          INTERNAL_GW: ((gcp_subnet(@= stemcell.version @)_deploy_director_ipv4.gw))
+          RESERVED_RANGE: ((gcp_subnet(@= stemcell.version @)_deploy_director_ipv4.reserved_range))
           TAG: test-stemcells-ipv4
       - attempts: 3
         file: bosh-stemcells-ci/tasks/test-stemcell.yml
@@ -756,24 +756,24 @@ jobs:
           GCP_PROJECT_ID: ((gcp_project_id))
           GCP_ZONE: europe-west4-a
           GCP_NETWORK_NAME: default
-          GCP_SUBNET_NAME: bosh-integration2
           GCP_JSON_KEY: ((gcp_json_key))
-          INTERNAL_IP: 10.100.1.10
-          INTERNAL_CIDR: 10.100.1.0/24
-          INTERNAL_GW: 10.100.1.1
-          RESERVED_RANGE: '10.100.1.2 - 10.100.1.9'
+          GCP_SUBNET_NAME: ((gcp_subnet(@= stemcell.version @)_deploy_director.name))
+          INTERNAL_IP: ((gcp_subnet(@= stemcell.version @)_deploy_director.ip))
+          INTERNAL_CIDR: ((gcp_subnet(@= stemcell.version @)_deploy_director.cidr))
+          INTERNAL_GW: ((gcp_subnet(@= stemcell.version @)_deploy_director.gw))
+          RESERVED_RANGE: ((gcp_subnet(@= stemcell.version @)_deploy_director.reserved_range))
           TAG: test-stemcells-bats
       - file: bosh-stemcells-ci/tasks/bats/iaas/gcp/prepare-bats-config.yml
         params:
           VARS_STEMCELL_NAME: bosh-google-kvm-ubuntu-(@= stemcell.os @)-go_agent
           VARS_NETWORK_DEFAULT: default
-          VARS_SUBNETWORK_DEFAULT: bosh-integration3
-          VARS_CIDR_DEFAULT: "10.100.2.0/24"
-          VARS_RESERVED_DEFAULT: '10.100.2.2 - 10.100.2.9'
-          VARS_STATIC_DEFAULT: '10.100.2.10 - 10.100.2.30'
-          VARS_STATIC_IP_DEFAULT: 10.100.2.30
-          VARS_STATIC_IP_DEFAULT-2: 10.100.2.15
-          VARS_GATEWAY_DEFAULT: 10.100.2.1
+          VARS_SUBNETWORK_DEFAULT: ((gcp_subnet(@= stemcell.version @)_prepare_bats.name))
+          VARS_STATIC_IP_DEFAULT: ((gcp_subnet(@= stemcell.version @)_prepare_bats.ip))
+          VARS_STATIC_IP_DEFAULT-2: ((gcp_subnet(@= stemcell.version @)_prepare_bats.ip2))
+          VARS_CIDR_DEFAULT: ((gcp_subnet(@= stemcell.version @)_prepare_bats.cidr))
+          VARS_GATEWAY_DEFAULT: ((gcp_subnet(@= stemcell.version @)_prepare_bats.gw))
+          VARS_RESERVED_DEFAULT: ((gcp_subnet(@= stemcell.version @)_prepare_bats.reserved_range))
+          VARS_STATIC_DEFAULT: ((gcp_subnet(@= stemcell.version @)_prepare_bats.static_range))
           VARS_TAG: test-stemcells-bats
         task: prepare-bats
       - file: bats/ci/tasks/run-bats.yml


### PR DESCRIPTION
To support testing and building multiple stemcell lines in parallel, the
subnets have to be made configurable to avoid ip clashes.